### PR TITLE
[Swift] Add support for emitting FHIR unions

### DIFF
--- a/backends/swift/src/enum.ml
+++ b/backends/swift/src/enum.ml
@@ -23,11 +23,9 @@ let name t = t.name
 let pp_case fmt str =
   Fmt.pf fmt "case %s = \"%s\"" (String.uncapitalize str) str
 
-let case_sep fmt () =
-  Fmt.pf fmt "@\n@\n"
 
 let pp_enum_options fmt t =
-  let cases = Fmt.list ~sep:case_sep pp_case in
+  let cases = Fmt.list ~sep:Formatters.case_sep pp_case in
   Fmt.pf fmt "@\n%a@\n" cases t.cases
 
 let pp_enum_surround fmt t =

--- a/backends/swift/src/formatters.ml
+++ b/backends/swift/src/formatters.ml
@@ -5,3 +5,7 @@ let surround p1 p2 pp_v fmt v =
 
 let nline fmt _ =
   Fmt.pf fmt "%s" "\n"
+
+(** [fmt] for adding new lines before enum cases*)
+let case_sep fmt () =
+  Fmt.pf fmt "@\n@\n"

--- a/backends/swift/src/sum.ml
+++ b/backends/swift/src/sum.ml
@@ -1,0 +1,53 @@
+open! Base
+
+module Option = struct
+  type t = {
+    name: string;
+    typ: string;
+  }
+
+  let create name typ = {
+    name;
+    typ
+  }
+
+  let pp fmt t =
+    Fmt.pf fmt "case %s(%s)" t.name t.typ
+
+  let t_of_datatype dt =
+    match dt with
+    | Lib.Fhir.Scalar s ->
+      let name = Swift_field.datatype_to_string s.scalar_type in
+      { name = String.uncapitalize name ; typ=name}
+    | Lib.Fhir.Union u -> {name = u.l2; typ = u.l2}
+    | Lib.Fhir.Arity a ->
+      let typ = Swift_field.datatype_to_string a.ft2 in
+      let name = String.uncapitalize a.l3 in
+      {name; typ}
+    | Lib.Fhir.Complex c ->
+      {name = c.name; typ = c.name}
+
+end
+
+type t = {
+  name: string;
+  options: Option.t list;
+}
+
+let create name options = {
+  name;
+  options
+}
+
+let t_of_union union =
+  {
+    name = union;
+    options = [];
+  }
+
+let pp_cases fmt t =
+  let lst = Fmt.list ~sep:Formatters.case_sep Option.pp in
+  Fmt.pf fmt "@\n%a@\n" lst t.options
+
+let pp fmt t =
+  Fmt.pf fmt "public enum %s %a" t.name (Fmt.braces pp_cases) t

--- a/backends/swift/src/sum.mli
+++ b/backends/swift/src/sum.mli
@@ -1,0 +1,22 @@
+open! Base
+
+module Option: sig
+  type t
+
+  val create: string -> string -> t
+
+  val pp: Formatter.t -> t -> unit
+
+  val t_of_datatype: 'a Lib.Fhir.fhir_datatype -> t
+end
+
+
+
+type t
+
+
+val create: string -> Option.t list -> t
+
+val t_of_union: string -> t
+
+val pp: Formatter.t -> t -> unit

--- a/backends/swift/test/e2e/patient.t/run.t
+++ b/backends/swift/test/e2e/patient.t/run.t
@@ -43,3 +43,22 @@
   self.Id=Id
   self.Name=Name
   }}
+
+  $ ../../integration.exe patient_union
+  import Foundation
+  
+  
+   class Patient {
+  public var Deceased: PatientDeceased?
+                  
+  public var Name: String
+  
+  init (Name: String){
+  self.Name=Name
+  }}
+  
+  public enum PatientDeceased {
+                               case bool(Bool)
+                               
+                               case date(Date)
+                               }

--- a/backends/swift/test/resources.ml
+++ b/backends/swift/test/resources.ml
@@ -51,6 +51,36 @@ let patient_arity_opt () =
     }
   ]
 
+let patient_union () =
+  Lib.Structure.make "Patient" [
+    F.Field {
+      path = Lib.Path.from_string "Patient.Name";
+      id = "Patient.Name";
+      datatype = Lib.Fhir.Scalar {
+          scalar_type = D.Simple P.String;
+          required = true;
+        }
+    };
+    F.Field {
+      path = Lib.Path.from_string "Patient.deceased[x]";
+      id = "Patient.deceased[x]";
+      datatype = F.Union {
+          l2 = "deceased";
+          field_types = [
+            F.Scalar {
+              scalar_type = D.Simple P.Boolean;
+              required = false;
+            };
+            F.Scalar {
+              scalar_type = D.Simple P.DateTime;
+              required = false;
+            }
+          ]
+        }
+    }
+  ]
+
+
 let patient_arity_req () =
   Lib.Structure.make "Patient" [
     F.Field {
@@ -210,4 +240,5 @@ let v () =
   Hashtbl.set table ~key:"patient_arity_required" ~data:(Lib.Resource.Structure (patient_arity_req ()));
   Hashtbl.set table ~key:"account" ~data:(Lib.Resource.Structure (account ()));
   Hashtbl.set table ~key:"account_status" ~data:(Lib.Resource.CodeSystem (account_status ()));
+  Hashtbl.set table ~key:"patient_union" ~data:(Lib.Resource.Structure (patient_union ()));
   table

--- a/lib/src/simple_datatype.ml
+++ b/lib/src/simple_datatype.ml
@@ -47,4 +47,6 @@ let t_to_string dt =
   | Base64Binary -> "base64Binary"
   | String -> "string"
   | Integer -> "integer"
+  | Boolean -> "boolean"
+  | DateTime -> "dateTime"
   | _ -> raise (UnsupportedType "Can't with it")


### PR DESCRIPTION
Updated the swift backend to start emitting FHIR unions.

We're making use of Swift enums as a type of sum type.
As described here: https://mislavjavor.github.io/2017-04-19/Swift-enums-are-sum-types.-That-makes-them-very-interesting/